### PR TITLE
test expiration correctly

### DIFF
--- a/tests/src/test/java/io/openshift/booster/OpenshiftIT.java
+++ b/tests/src/test/java/io/openshift/booster/OpenshiftIT.java
@@ -78,7 +78,7 @@ public class OpenshiftIT {
     @Test
     public void cacheShouldExpire() throws InterruptedException {
         String first = getGreeting();
-        TimeUnit.SECONDS.sleep(11); // wait for cache expiration, default TTL is 10 seconds
+        TimeUnit.SECONDS.sleep(6); // wait for expiration, TTL of the cute name cache entry is 5 seconds
         String second = getGreeting();
 
         assertThat(first, is(not(second)));


### PR DESCRIPTION
The cache has default expiration time of 10 seconds, but
the cute name cache entry always has TTL of 5 seconds.
That should be tested correctly.